### PR TITLE
feat: 리프레시 토큰 재발급 기능 추가

### DIFF
--- a/runwithme/src/main/java/com/runwithme/runwithme/domain/user/controller/RefreshTokenController.java
+++ b/runwithme/src/main/java/com/runwithme/runwithme/domain/user/controller/RefreshTokenController.java
@@ -1,0 +1,36 @@
+package com.runwithme.runwithme.domain.user.controller;
+
+import com.runwithme.runwithme.domain.user.dto.RefreshTokenIssueDto;
+import com.runwithme.runwithme.domain.user.service.RefreshTokenService;
+import com.runwithme.runwithme.global.security.jwt.AuthToken;
+import com.runwithme.runwithme.global.utils.HeaderUtils;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/token")
+@RequiredArgsConstructor
+public class RefreshTokenController {
+
+    private final RefreshTokenService refreshTokenService;
+
+    @PostMapping
+    public ResponseEntity<Void> reIssue(@ModelAttribute RefreshTokenIssueDto dto, HttpServletResponse response) {
+        if (StringUtils.equals(dto.grantType(), "refresh_token")) {
+            AuthToken accessToken = refreshTokenService.reIssue(dto);
+            HeaderUtils.setAccessToken(response, accessToken.getToken());
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+}

--- a/runwithme/src/main/java/com/runwithme/runwithme/domain/user/dto/RefreshTokenDto.java
+++ b/runwithme/src/main/java/com/runwithme/runwithme/domain/user/dto/RefreshTokenDto.java
@@ -1,0 +1,10 @@
+package com.runwithme.runwithme.domain.user.dto;
+
+import java.time.LocalDateTime;
+
+public record RefreshTokenDto(
+    String tokenName,
+    String userEmail,
+    LocalDateTime expiredDatetime
+) {
+}

--- a/runwithme/src/main/java/com/runwithme/runwithme/domain/user/dto/RefreshTokenIssueDto.java
+++ b/runwithme/src/main/java/com/runwithme/runwithme/domain/user/dto/RefreshTokenIssueDto.java
@@ -1,0 +1,7 @@
+package com.runwithme.runwithme.domain.user.dto;
+
+public record RefreshTokenIssueDto(
+    String grantType,
+    String refreshToken
+) {
+}

--- a/runwithme/src/main/java/com/runwithme/runwithme/domain/user/entity/RefreshToken.java
+++ b/runwithme/src/main/java/com/runwithme/runwithme/domain/user/entity/RefreshToken.java
@@ -1,0 +1,34 @@
+package com.runwithme.runwithme.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @Column(name = "rt_name")
+    private String name;
+
+    @Column(name = "rt_user_email")
+    private String userEmail;
+
+    @Column(name = "rt_expired_datetime")
+    private LocalDateTime expiredDateTime;
+
+    @Builder
+    public RefreshToken(String name, String userEmail, LocalDateTime expiredDateTime) {
+        this.name = name;
+        this.userEmail = userEmail;
+        this.expiredDateTime = expiredDateTime;
+    }
+}

--- a/runwithme/src/main/java/com/runwithme/runwithme/domain/user/repository/RefreshTokenRepository.java
+++ b/runwithme/src/main/java/com/runwithme/runwithme/domain/user/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package com.runwithme.runwithme.domain.user.repository;
+
+import com.runwithme.runwithme.domain.user.entity.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+}

--- a/runwithme/src/main/java/com/runwithme/runwithme/domain/user/service/RefreshTokenService.java
+++ b/runwithme/src/main/java/com/runwithme/runwithme/domain/user/service/RefreshTokenService.java
@@ -1,0 +1,58 @@
+package com.runwithme.runwithme.domain.user.service;
+
+import com.runwithme.runwithme.domain.user.dto.RefreshTokenDto;
+import com.runwithme.runwithme.domain.user.dto.RefreshTokenIssueDto;
+import com.runwithme.runwithme.domain.user.entity.RefreshToken;
+import com.runwithme.runwithme.domain.user.entity.User;
+import com.runwithme.runwithme.domain.user.repository.RefreshTokenRepository;
+import com.runwithme.runwithme.domain.user.repository.UserRepository;
+import com.runwithme.runwithme.global.error.CustomException;
+import com.runwithme.runwithme.global.result.ResultCode;
+import com.runwithme.runwithme.global.security.jwt.AuthToken;
+import com.runwithme.runwithme.global.security.jwt.AuthTokenFactory;
+import com.runwithme.runwithme.global.security.properties.JwtProperties;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+    private final AuthTokenFactory tokenFactory;
+    private final JwtProperties properties;
+
+    public void save(RefreshTokenDto dto) {
+        RefreshToken entity = RefreshToken.builder()
+                .name(dto.tokenName())
+                .userEmail(dto.userEmail())
+                .expiredDateTime(dto.expiredDatetime())
+                .build();
+
+        refreshTokenRepository.save(entity);
+    }
+
+    public AuthToken reIssue(RefreshTokenIssueDto dto) {
+        RefreshToken token = refreshTokenRepository.findById(dto.refreshToken()).orElseThrow(() -> new CustomException(ResultCode.UNSUPPORTED_JWT_TOKEN));
+        AuthToken authToken = tokenFactory.convertAuthToken(token.getName());
+        if (authToken.validate()) {
+            User user = userRepository.findByEmail(token.getUserEmail()).orElseThrow(() -> new CustomException(ResultCode.USER_NOT_FOUND));
+            return tokenFactory.createAuthToken(user.getEmail(), user.getRole().toString(), new Date(System.currentTimeMillis() + properties.accessTokenExpiry));
+        } else {
+            throw new CustomException(ResultCode.UNSUPPORTED_JWT_TOKEN);
+        }
+    }
+
+    private boolean isExpired(LocalDateTime expiredDatetime) {
+        LocalDateTime now = LocalDateTime.now();
+        return now.isAfter(expiredDatetime);
+    }
+}

--- a/runwithme/src/main/java/com/runwithme/runwithme/global/security/config/SecurityConfig.java
+++ b/runwithme/src/main/java/com/runwithme/runwithme/global/security/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.runwithme.runwithme.global.security.config;
 
+import com.runwithme.runwithme.domain.user.service.RefreshTokenService;
 import com.runwithme.runwithme.global.error.CustomException;
 import com.runwithme.runwithme.global.security.filter.CustomAuthenticationFilter;
 import com.runwithme.runwithme.global.security.filter.TokenAuthorizationFilter;
@@ -53,6 +54,7 @@ public class SecurityConfig {
             "/users/duplicate-email",
             "/users/duplicate-nickname",
             "/users/**/profile-image",
+            "/token"
     };
 
     private final AuthTokenFactory authTokenFactory;
@@ -62,6 +64,8 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
 
     private final DelegatedAuthenticationEntryPoint authEntryPoint;
+
+    private final RefreshTokenService refreshTokenService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -113,7 +117,7 @@ public class SecurityConfig {
 
         customAuthenticationFilter.setFilterProcessesUrl("/users/login");
         customAuthenticationFilter.setAuthenticationManager(authenticationManager());
-        customAuthenticationFilter.setAuthenticationSuccessHandler(new CustomAuthenticationSuccessHandler(authTokenFactory, properties));
+        customAuthenticationFilter.setAuthenticationSuccessHandler(new CustomAuthenticationSuccessHandler(authTokenFactory, properties, refreshTokenService));
         customAuthenticationFilter.setAuthenticationFailureHandler(new CustomAuthenticationFailureHandler());
 
         return customAuthenticationFilter;

--- a/runwithme/src/main/java/com/runwithme/runwithme/global/security/filter/TokenAuthorizationFilter.java
+++ b/runwithme/src/main/java/com/runwithme/runwithme/global/security/filter/TokenAuthorizationFilter.java
@@ -38,6 +38,7 @@ public class TokenAuthorizationFilter extends OncePerRequestFilter {
                 "/users/duplicate-email",
                 "/users/duplicate-nickname",
                 "/users/**/profile-image",
+                "/token"
         };
         return Arrays.stream(PERMIT_URL_PATHS)
                 .anyMatch(e -> new AntPathMatcher().match(e, request.getServletPath()));

--- a/runwithme/src/main/java/com/runwithme/runwithme/global/security/handler/CustomAuthenticationSuccessHandler.java
+++ b/runwithme/src/main/java/com/runwithme/runwithme/global/security/handler/CustomAuthenticationSuccessHandler.java
@@ -3,8 +3,10 @@ package com.runwithme.runwithme.global.security.handler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.runwithme.runwithme.domain.user.dto.RefreshTokenDto;
 import com.runwithme.runwithme.domain.user.dto.converter.UserConverter;
 import com.runwithme.runwithme.domain.user.entity.User;
+import com.runwithme.runwithme.domain.user.service.RefreshTokenService;
 import com.runwithme.runwithme.global.result.ResultCode;
 import com.runwithme.runwithme.global.result.ResultResponseDto;
 import com.runwithme.runwithme.global.security.jwt.AuthToken;
@@ -25,6 +27,7 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.time.LocalDateTime;
 import java.util.Date;
 
 import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.REFRESH_TOKEN;
@@ -35,6 +38,7 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
 
     private final AuthTokenFactory tokenFactory;
     private final JwtProperties properties;
+    private final RefreshTokenService refreshTokenService;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
@@ -48,7 +52,8 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         setResponseBody(user, response);
 
-        AuthToken refreshToken = tokenFactory.createAuthToken(properties.secret, new Date(System.currentTimeMillis() + properties.refreshTokenExpiry));
+        AuthToken refreshToken = tokenFactory.createAuthToken(null, new Date(System.currentTimeMillis() + properties.refreshTokenExpiry));
+        refreshTokenService.save(new RefreshTokenDto(refreshToken.getToken(), user.getEmail(), LocalDateTime.now().plusSeconds(properties.refreshTokenExpiry / 1000)));
         log.debug("Successful Authentication :: RefreshToken : {}", refreshToken.getToken());
         CookieUtils.deleteCookie(request, response, REFRESH_TOKEN);
         CookieUtils.addCookie(response, REFRESH_TOKEN, refreshToken.getToken(), properties.refreshTokenExpiry);


### PR DESCRIPTION
- RefreshToken Entity 추가
- 액세스 토큰 재발급 API 기능 추가
- 리프레시 토큰은 현재 배포된 개발 서버 DB에 저장
- 재발급 시 토큰 검증은 어플리케이션 서버 내에서만 진행